### PR TITLE
Add the 'weekdays' token

### DIFF
--- a/lib/midnight/repeater.rb
+++ b/lib/midnight/repeater.rb
@@ -76,7 +76,8 @@ class Midnight::Repeater < Chronic::Tag #:nodoc:
       /^th(urs|ers)day?s?$/ => :thursday,
       /^thu$/ => :thursday,
       /^fr[iy](day)?s?$/ => :friday,
-      /^sat(t?[ue]rday)?s?$/ => :saturday
+      /^sat(t?[ue]rday)?s?$/ => :saturday,
+      /^weekdays?$/ => :weekday,
     }
 
     day_sequence = {
@@ -86,7 +87,8 @@ class Midnight::Repeater < Chronic::Tag #:nodoc:
       :wednesday => 3,
       :thursday => 4,
       :friday => 5,
-      :saturday => 6
+      :saturday => 6,
+      :weekday => '1-5',
     }
 
     scanner.each do |scanner_item, day|

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -41,7 +41,8 @@ class TestParsing < Test::Unit::TestCase
       'midnight on tuesdays' => '0 0 * * 2',
       'every 5 minutes on Tuesdays' => '*/5 * * * 2',
       'every other day' => nil, # other is currently unsupported
-      'noon' => '0 12 * * *'
+      'noon' => '0 12 * * *',
+      'midnight on weekdays' => '0 0 * * 1-5'
     }
 
     expected_results.each do |search,cron_string|


### PR DESCRIPTION
I'd like to be able to use the following text:

`midnight on weekdays`

and have it translated into a valid cron with the day range set correctly:

`'0 0 * * 1-5'`

